### PR TITLE
Register symbols in packages correctly

### DIFF
--- a/aark.asd
+++ b/aark.asd
@@ -1,4 +1,4 @@
-(in-package #:cl-user)
+(in-package :cl-user)
 
 (asdf:defsystem :aark
   :depends-on (:sdl2

--- a/aark.lisp
+++ b/aark.lisp
@@ -1,4 +1,4 @@
-(in-package #:aark)
+(in-package :aark)
 
 (defun main (&key (core-is-root nil))
   (defparameter +root+

--- a/game-menu.lisp
+++ b/game-menu.lisp
@@ -1,4 +1,4 @@
-(in-package #:aark)
+(in-package :aark)
 
 (defclass game-menu-state (state)
   ((choise :initform 0)))

--- a/packages.lisp
+++ b/packages.lisp
@@ -1,7 +1,7 @@
-(in-package #:cl-user)
+(in-package :cl-user)
 
-(defpackage #:aark
+(defpackage aark
   (:documentation "Arkanoid game main package")
   (:use :cl)
   (:export
-   #:main))
+   :main))


### PR DESCRIPTION
\`#:symbol' creates uninterned symbol that doesn't belong to any
package.

Also I checked defpackage's in clack and did same.

Signed-off-by: Pavel Kulyov <pkulev@croc.ru>